### PR TITLE
Prefer mcs over dmcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ endif
 ifeq ($(platform), iOS)
 	csharp = /Developer/MonoTouch/usr/bin/smcs /nologo $(debug_csharp)
 else
-	csharp = dmcs /nologo $(debug_csharp)
+	csharp = mcs /nologo $(debug_csharp)
 endif
 csharpdefines ?=
 publicjavadir = OpenHome/Net/Bindings/Java/

--- a/T4Linux.mak
+++ b/T4Linux.mak
@@ -32,7 +32,7 @@ dllsources =	OpenHome/Net/T4/TextTemplating/Mono.TextTemplating/AssemblyInfo.cs 
 
 $(toolsDir)Mono.TextTemplating.dll : $(dllsources)
 	$(mkdir) $(toolsDir)
-	dmcs /t:library -out:$(toolsDir)Mono.TextTemplating.dll $(dllsources)
+	mcs /t:library -out:$(toolsDir)Mono.TextTemplating.dll $(dllsources)
 
  
 exesources =	OpenHome/Net/T4/TextTemplating/TextTransform/AssemblyInfo.cs \


### PR DESCRIPTION
This gets rid of `warning CS8001: SDK path could not be resolved` error while compiling.
